### PR TITLE
Select multiple

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -133,14 +133,26 @@ namespace App\Models{
  * App\Models\Cultivo
  *
  * @property int $id
- * @property int $lkp_cultivo_id
- * @property int|null $lkp_variedad_id
- * @property int $parcela_id
+ * @property string $lkp_cultivo_id
+ * @property string|null $lkp_variedad_id
+ * @property string $parcela_id
  * @property string|null $propiedad_cultivo
  * @property string|null $propiedad_variedad
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Enfermedade[] $enfermedades
+ * @property-read int|null $enfermedades_count
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Fenologia[] $fenologias
+ * @property-read int|null $fenologias_count
+ * @property-read \App\Models\LkpCultivo $lkp_cultivos
+ * @property-read \App\Models\LkpVariedad|null $lkp_variedad
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\ManejoParcela[] $manejo_parcelas
+ * @property-read int|null $manejo_parcelas_count
  * @property-read \App\Models\Parcela $parcela
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Plaga[] $plagas
+ * @property-read int|null $plagas_count
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Rendimento[] $rendimentos
+ * @property-read int|null $rendimentos_count
  * @method static \Illuminate\Database\Eloquent\Builder|Cultivo newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Cultivo newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Cultivo query()
@@ -458,13 +470,25 @@ namespace App\Models{
  * @property int $location
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property string|null $select_multiple if this is set, this data map is for data at a different level, based on a select_multiple and possibly a repeat group based on that select_multiple response.
+ * @property string|null $repeat_group the name of the repeat group to look inside to find the main variables for this data map
+ * @property string|null $select_multiple_other the name of the "enter other value" question linked to the select_multiple variable
+ * @property string|null $inner_name
+ * @property string|null $inner_label
+ * @property string|null $select_multiple_other_label the name of the "enter other value" question linked to the select_multiple variable
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap query()
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereInnerLabel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereInnerName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereLocation($value)
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereModel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereRepeatGroup($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereSelectMultiple($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereSelectMultipleOther($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereSelectMultipleOtherLabel($value)
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereTitle($value)
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereUpdatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|DataMap whereVariables($value)
@@ -476,7 +500,7 @@ namespace App\Models{
 /**
  * App\Models\DataTemplate
  *
- * @property string $fecha_hora
+ * @property string|null $fecha_hora
  * @property int $id
  * @property int|null $intervalo
  * @property string|null $temperatura_interna
@@ -647,17 +671,18 @@ namespace App\Models{
  *
  * @property int $id
  * @property int $cultivo_id
- * @property string|null $enfermedad_nombre
+ * @property string|null $name
  * @property int $submission_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Cultivo $cultivo
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade query()
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade whereCultivoId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade whereEnfermedadNombre($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade whereSubmissionId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enfermedade whereUpdatedAt($value)
  */
@@ -670,7 +695,6 @@ namespace App\Models{
  *
  * @property int $id
  * @property int $cultivo_id
- * @property int|null $variedad_id
  * @property int|null $epoca_siembra
  * @property string|null $fecha_siembra
  * @property string|null $fecha_emergencia
@@ -686,6 +710,7 @@ namespace App\Models{
  * @property int $submission_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Cultivo $cultivo
  * @method static \Illuminate\Database\Eloquent\Builder|Fenologia newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Fenologia newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Fenologia query()
@@ -706,9 +731,53 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|Fenologia whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Fenologia whereSubmissionId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Fenologia whereUpdatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Fenologia whereVariedadId($value)
  */
 	class Fenologia extends \Eloquent {}
+}
+
+namespace App\Models{
+/**
+ * App\Models\LkpCultivo
+ *
+ * @property int $id
+ * @property string $name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Cultivo[] $cultivos
+ * @property-read int|null $cultivos_count
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\LkpVariedad[] $variedad
+ * @property-read int|null $variedad_count
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpCultivo newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpCultivo newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpCultivo query()
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpCultivo whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpCultivo whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpCultivo whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpCultivo whereUpdatedAt($value)
+ */
+	class LkpCultivo extends \Eloquent {}
+}
+
+namespace App\Models{
+/**
+ * App\Models\LkpVariedad
+ *
+ * @property int $id
+ * @property int $lkp_cultivo_id
+ * @property string $name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\LkpCultivo $lkp_cultivo
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad query()
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad whereLkpCultivoId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LkpVariedad whereUpdatedAt($value)
+ */
+	class LkpVariedad extends \Eloquent {}
 }
 
 namespace App\Models{
@@ -744,6 +813,7 @@ namespace App\Models{
  * @property int $submission_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Cultivo $cultivo
  * @method static \Illuminate\Database\Eloquent\Builder|ManejoParcela newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ManejoParcela newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ManejoParcela query()
@@ -854,6 +924,28 @@ namespace App\Models{
 
 namespace App\Models{
 /**
+ * App\Models\MuestraSuelo
+ *
+ * @property int $id
+ * @property string $parcela_id
+ * @property int $submission_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Parcela $parcela
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo query()
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo whereParcelaId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo whereSubmissionId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|MuestraSuelo whereUpdatedAt($value)
+ */
+	class MuestraSuelo extends \Eloquent {}
+}
+
+namespace App\Models{
+/**
  * App\Models\Municipio
  *
  * @property int $id
@@ -896,7 +988,13 @@ namespace App\Models{
  * @property int $submission_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Cultivo[] $cultivos
+ * @property-read int|null $cultivos_count
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\MuestraSuelo[] $muestra_suelos
+ * @property-read int|null $muestra_suelos_count
  * @property-read \App\Models\Submission $submissions
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Suelo[] $suelos
+ * @property-read int|null $suelos_count
  * @method static \Illuminate\Database\Eloquent\Builder|Parcela newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Parcela newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Parcela query()
@@ -926,21 +1024,32 @@ namespace App\Models{
  *
  * @property int $id
  * @property int $cultivo_id
- * @property string|null $plaga_nombre
+ * @property string|null $name
  * @property string|null $cantidad_insectos_m2
+ * @property string|null $cantidad_larvas
+ * @property int|null $mosca_numero
+ * @property int|null $mosca_trampas
+ * @property int|null $mosca_dias
+ * @property int|null $presencia_mosca
  * @property string|null $plaga_fecha
  * @property int $submission_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Cultivo $cultivo
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga query()
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereCantidadInsectosM2($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereCantidadLarvas($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereCultivoId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereMoscaDias($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereMoscaNumero($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereMoscaTrampas($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga wherePlagaFecha($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plaga wherePlagaNombre($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Plaga wherePresenciaMosca($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereSubmissionId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Plaga whereUpdatedAt($value)
  */
@@ -997,7 +1106,6 @@ namespace App\Models{
  * @property int $cultivo_id
  * @property string|null $cantidad_cosechada_kg
  * @property string|null $superficie_cosechada_m2
- * @property string|null $plantas_cosechada
  * @property string|null $peso_muestra_tuberculos
  * @property string|null $peso_danados_tuberculos
  * @property string|null $peso_muestra_grano
@@ -1005,10 +1113,13 @@ namespace App\Models{
  * @property int $submission_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property string|null $cantidad_cosechada_p
+ * @property-read \App\Models\Cultivo $cultivo
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento query()
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereCantidadCosechadaKg($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereCantidadCosechadaP($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereCultivoId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereId($value)
@@ -1016,7 +1127,6 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento wherePesoDanadosTuberculos($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento wherePesoMuestraGrano($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento wherePesoMuestraTuberculos($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Rendimento wherePlantasCosechada($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereSubmissionId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereSuperficieCosechadaM2($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Rendimento whereUpdatedAt($value)
@@ -1093,10 +1203,11 @@ namespace App\Models{
  * @property string $parcela_id
  * @property string $materia_organica
  * @property string $textura
- * @property int $pH
+ * @property string $pH
  * @property int $submission_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Parcela $parcela
  * @method static \Illuminate\Database\Eloquent\Builder|Suelo newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Suelo newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Suelo query()
@@ -1230,17 +1341,6 @@ namespace App\Models{
 
 namespace App\Models{
 /**
- * App\Models\Variedad
- *
- * @method static \Illuminate\Database\Eloquent\Builder|Variedad newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|Variedad newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|Variedad query()
- */
-	class Variedad extends \Eloquent {}
-}
-
-namespace App\Models{
-/**
  * App\Models\Xlsform
  *
  * @property int $id
@@ -1257,7 +1357,6 @@ namespace App\Models{
  * @property int $live If true, this form is available to projects to use
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- * @property string $data_map_id
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Submission[] $submissions
  * @property-read int|null $submissions_count
  * @method static \Illuminate\Database\Eloquent\Builder|Xlsform newModelQuery()
@@ -1265,7 +1364,6 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|Xlsform query()
  * @method static \Illuminate\Database\Eloquent\Builder|Xlsform whereContent($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Xlsform whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Xlsform whereDataMapId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Xlsform whereDescription($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Xlsform whereEnketoUrl($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Xlsform whereId($value)

--- a/app/Http/Controllers/Admin/DataCrudController.php
+++ b/app/Http/Controllers/Admin/DataCrudController.php
@@ -206,8 +206,6 @@ class DataCrudController extends CrudController
         $base_path = base_path();
         $query = Session('query');
         $params = join(",",Session('params'));
-        $query = '"'.$query.'"';
-        $params = '"'.$params.'"';
         $date = str_replace(':', '', date('c'));
         $date = str_replace('-', '', $date);
         $date = str_replace('+', '', $date);

--- a/app/Http/Controllers/Admin/DataMapCrudController.php
+++ b/app/Http/Controllers/Admin/DataMapCrudController.php
@@ -77,7 +77,7 @@ class DataMapCrudController extends CrudController
             [
                 'name' => 'title',
                 'type' => 'text',
-               'label' => 'Give the title / label for the data map',
+                'label' => 'Give the title / label for the data map',
             ],
             [
                 'name' => 'model',
@@ -101,6 +101,35 @@ class DataMapCrudController extends CrudController
                 'type' => 'boolean',
                 'hint' => 'The ODK variable name should be `location`',
                 'label' => 'Does this data map include a `location` field? (Note, this will probably be NO for every module except Parcela...)',
+            ],
+            [
+                'name' => 'levels_title',
+                'type' => 'custom_html',
+                'value' => '<h4>Data Levels / Repeat Group Options</h4><p>If this data map gets data from a select_multiple and associated repeat group, enter those details here. <b>NOTE: ALL the variables added to the "variables" section below MUST be within the repeat group in the ODK form.</b></p>'
+            ],
+            [
+                'name' => 'select_multiple',
+                'label' => 'Name of the select_multiple variable',
+            ],
+            [
+                'name' => 'select_multiple_other',
+                'label' => 'If the select_multiple question has an "other" option, enter the value used for "other" in the choice list.',
+            ],
+            [
+                'name' => 'select_multiple_other_label',
+                'label' => 'If the select_multiple question has a custom "enter other value" question, add the name of that question.',
+            ],
+            [
+                'name' => 'repeat_group',
+                'label' => 'Name of the repeat group',
+            ],
+            [
+                'name' => 'inner_name',
+                'label' => 'Which variable calculates the selected-at() to pull the selected item into the repeat group? (If no variable does this, leave it blank',
+            ],
+            [
+                'name' => 'inner_label',
+                'label' => 'Which variable calculates the jr:choice-name() to pull the selected item label into the repeat group? (If no variable does this, leave it blank',
             ],
             [
                 'name' => 'variables',

--- a/app/Http/Controllers/DataMapController.php
+++ b/app/Http/Controllers/DataMapController.php
@@ -16,6 +16,8 @@ class DataMapController extends Controller
     {
         // if the map references a select_multiple and repeat group, then we're creating data at a lower level
         if ($dataMap->select_multiple && $dataMap->select_multiple !== "") {
+            \Log::info("select_multiple and repeat group being handled");
+            \Log::info($data);
             foreach ($data[$dataMap->repeat_group] as $repeatData) {
                 // bring references to lower levels back into repeatData
                 // reference to submission

--- a/app/Http/Controllers/DataMapController.php
+++ b/app/Http/Controllers/DataMapController.php
@@ -12,46 +12,76 @@ use App\Jobs\ImportAttachmentFromKobo;
 
 class DataMapController extends Controller
 {
-    public static function newRecord(DataMap $dataMap, Array $data)
+    public static function newRecord(DataMap $dataMap, array $data)
     {
-		
-    	$newModel = DataMapController::createNewModel($dataMap, $data);
-		$class = 'App\\Models\\'.$dataMap->model;
-	    $newItem = new $class();
-	    $newItem->fill($newModel);
-	    $newItem->save();
+        // if the map references a select_multiple and repeat group, then we're creating data at a lower level
+        if ($dataMap->select_multiple && $dataMap->select_multiple !== "") {
+            foreach ($data[$dataMap->repeat_group] as $repeatData) {
+                // bring references to lower levels back into repeatData
+                // reference to submission
+                $repeatData['_id'] =  $data['_id'];
+                // reference to crop
+                $repeatData['cultivo_id'] =  $data['cultivo_id'];
+
+                // if there is an 'other' option, deal with it
+                if ($dataMap->select_multiple_other) {
+
+                    // check if the current repeat is for the 'other' option:
+                    if ($repeatData[$dataMap->inner_name] === $dataMap->select_multiple_other) {
+
+                        // if it is, then bring in the 'specify other' response from outside the repeat group
+                        $repeatData[$dataMap->inner_label] = $data[$dataMap->select_multiple_other_label];
+                    }
+                }
+
+                $newItem = DataMapController::makeNewRecord($dataMap, $repeatData);
+            }
+        } else {
+            $newItem = DataMapController::makeNewRecord($dataMap, $data);
+        }
+
+        return $newItem;
+    }
+
+    public static function makeNewRecord(DataMap $dataMap, array $data)
+    {
+        $newModel = DataMapController::createNewModel($dataMap, $data);
+        $class = 'App\\Models\\'.$dataMap->model;
+        $newItem = new $class();
+        $newItem->fill($newModel);
+        $newItem->save();
         return $newItem;
     }
 
     //update exists plot
-    public static function updateRecord(DataMap $dataMap, Array $data, $id)
+    public static function updateRecord(DataMap $dataMap, array $data, $id)
     {
-    	$model = DataMapController::createNewModel($dataMap, $data);
-    	$class = 'App\\Models\\'.$dataMap->model;
-	    $class::where('id', $id)->update($model);
+        $model = DataMapController::createNewModel($dataMap, $data);
+        $class = 'App\\Models\\'.$dataMap->model;
+        $class::where('id', $id)->update($model);
         return $model;
     }
 
-    public static function createNewModel(DataMap $dataMap, Array $data)
+    public static function createNewModel(DataMap $dataMap, array $data)
     {
-    	//add the submission_id    		
-		$newModel = [
-        "submission_id" => $data['_id']
-    	];
+        //add the submission_id
+        $newModel = [
+            "submission_id" => $data['_id']
+        ];
 
 
-    	// split the gps coordinates into longitude, latitude, altitude and accuracy 
-    	if($dataMap->location && isset($data['gps']) && $data['gps']) {
+        // split the gps coordinates into longitude, latitude, altitude and accuracy
+        if ($dataMap->location && isset($data['gps']) && $data['gps']) {
             $location = explode(" ", $data['gps']);
             $newModel["longitude"] = isset($location[1]) ? $location[1] : null;
             $newModel["latitude"] = isset($location[0]) ? $location[0] : null;
             $newModel["altitude"] = isset($location[2]) ? $location[2] : null;
             $newModel["accuracy"] = isset($location[3]) ? $location[3] : null;
-    	}
-	
-		foreach($dataMap->variables as $variable) {
-			// if the variable is new (i.e. hasn't been manually added to the database)
-            if($variable['in_db'] == 0) {
+        }
+
+        foreach ($dataMap->variables as $variable) {
+            // if the variable is new (i.e. hasn't been manually added to the database)
+            if ($variable['in_db'] == 0) {
                 //don't actually process it (as the SQL Insert will fail)
                 //just tell the admin about it!
                 NewDataVariableSpotted::dispatch($variable['name']);
@@ -86,7 +116,7 @@ class DataMapController extends Controller
                 break;
 
                 case 'photo':
-                    if(isset($data[$variableName]) && $data[$variableName]) {
+                    if (isset($data[$variableName]) && $data[$variableName]) {
                         $value = $data[$variableName];
                         // ImportAttachmentFromKobo::dispatch($value, $data);
                     }
@@ -116,14 +146,12 @@ class DataMapController extends Controller
                 break;
             }
 
-            if(!is_null($value)) {
-            	//look the column name that matches to the variable name from the survey 
+            if (!is_null($value)) {
+                //look the column name that matches to the variable name from the survey
                 $newModel[$variable['column_name']] = $value;
             }
-		}
+        }
 
-		return $newModel;
-	
+        return $newModel;
     }
-
 }

--- a/app/Jobs/GetDataFromKobo.php
+++ b/app/Jobs/GetDataFromKobo.php
@@ -67,8 +67,7 @@ class GetDataFromKobo implements ShouldQueue
                 ]);
 
                 //merge all the modules
-                if (array_key_exists('modulo_loop/extra_modulo', $newSubmission['modulo_loop'][0] )) {
-                   
+                if (array_key_exists('modulo_loop/extra_modulo', $newSubmission['modulo_loop'][0])) {
                     $newSubmission['modulos'] = $newSubmission['modulos'] . ' ' . $newSubmission['modulo_loop'][0]['modulo_loop/extra_modulo'];
                 } else {
                     $newSubmission['modulos'] = $newSubmission['modulos'];
@@ -85,61 +84,61 @@ class GetDataFromKobo implements ShouldQueue
                     $newSubmission['modulo_loop'] = $newSubmission['modulo_loop'][0];
                 }
 
-                
+
                 // Create new parcela record if needed
                 if ($newSubmission['registrar_parcela'] == 1) {
                     //Update or create the record for all the locations
                     if ($newSubmission['region'] == 999) {
                         $region = Region::updateOrCreate([
                             'name' => $newSubmission['otra_region']
-                            ]);
-                            
-                            //update the region id value
-                            $newSubmission['region'] = $region->id;
-                        }
-                        
-                        if ($newSubmission['departamento'] == 999) {
-                            $departamento = Departamento::updateOrCreate([
-                                'region_id' => $newSubmission['region'],
-                                'name' => $newSubmission['otro_departamento']
-                                ]);
-                                
-                                //update the departamento id value
-                                $newSubmission['departamento'] = $departamento->id;
-                            }
-                            
-                            if ($newSubmission['municipio'] == 999) {
-                                $municipio = Municipio::updateOrCreate([
-                                    'departamento_id' => $newSubmission['departamento'],
-                                    'name' => $newSubmission['otro_municipio']
-                                    ]);
-                                    
-                                    //update the municipio id value
-                                    $newSubmission['municipio'] = $municipio->id;
-                                }
-                                
-                                if ($newSubmission['comunidad'] == 999) {
-                                    $location = explode(" ", $newSubmission['gps']);
-                                    $comunidad = Comunidad::updateOrCreate(
-                                        [
-                                            'municipio_id' => $newSubmission['municipio'],
-                                            'name' => $newSubmission['otra_comunidad']
-                                        ],
-                                        [
-                                            'latitude' => isset($location[0]) ? $location[0] : null,
-                                            'longitude' => isset($location[1]) ? $location[1] : null,
-                                            'altitude' => isset($location[2]) ? $location[2] : null
-                                        ]
-                                        );
-                                        $newSubmission['comunidad'] = $comunidad->id;
-                                    }
-                                    $dataMap = DataMap::findorfail('parcela');
-                                    DataMapController::newRecord($dataMap, $newSubmission);
-                                } else {
-                                    $dataMap = DataMap::findorfail('parcela');
-                                    DataMapController::updateRecord($dataMap, $newSubmission, $newSubmission['parcela_id']);
-                                }
-                                
+                        ]);
+
+                        //update the region id value
+                        $newSubmission['region'] = $region->id;
+                    }
+
+                    if ($newSubmission['departamento'] == 999) {
+                        $departamento = Departamento::updateOrCreate([
+                            'region_id' => $newSubmission['region'],
+                            'name' => $newSubmission['otro_departamento']
+                        ]);
+
+                        //update the departamento id value
+                        $newSubmission['departamento'] = $departamento->id;
+                    }
+
+                    if ($newSubmission['municipio'] == 999) {
+                        $municipio = Municipio::updateOrCreate([
+                            'departamento_id' => $newSubmission['departamento'],
+                            'name' => $newSubmission['otro_municipio']
+                        ]);
+
+                        //update the municipio id value
+                        $newSubmission['municipio'] = $municipio->id;
+                    }
+
+                    if ($newSubmission['comunidad'] == 999) {
+                        $location = explode(" ", $newSubmission['gps']);
+                        $comunidad = Comunidad::updateOrCreate(
+                            [
+                                'municipio_id' => $newSubmission['municipio'],
+                                'name' => $newSubmission['otra_comunidad']
+                            ],
+                            [
+                                'latitude' => isset($location[0]) ? $location[0] : null,
+                                'longitude' => isset($location[1]) ? $location[1] : null,
+                                'altitude' => isset($location[2]) ? $location[2] : null
+                            ]
+                        );
+                        $newSubmission['comunidad'] = $comunidad->id;
+                    }
+                    $dataMap = DataMap::findorfail('parcela');
+                    DataMapController::newRecord($dataMap, $newSubmission);
+                } else {
+                    $dataMap = DataMap::findorfail('parcela');
+                    DataMapController::updateRecord($dataMap, $newSubmission, $newSubmission['parcela_id']);
+                }
+
                 // Iterate through the other parcela-level modules.
                 foreach ($newSubmission['modulos'] as $parcelaModule) {
                     if ($parcelaModule === 'C') {
@@ -159,13 +158,11 @@ class GetDataFromKobo implements ShouldQueue
 
     public function processCultivoData($newSubmission)
     {
-
         foreach ($newSubmission['modulo_loop']['cultivo_loop'] as $cultivo) {
-
             $cultivo['modulos_cultivo'] = $newSubmission['modulo_loop']['cultivo_loop'][0]['modulos_cultivo'];
-            
+
             $dataMap = DataMap::findorfail('C');
-            
+
             if (count($cultivo['modulo_cultivo_loop'])==2) {
                 $cultivo['modulo_cultivo_loop'] = $cultivo['modulo_cultivo_loop'][0] + $cultivo['modulo_cultivo_loop'][1];
             } else {
@@ -173,13 +170,12 @@ class GetDataFromKobo implements ShouldQueue
             }
             $cultivo['parcela_id'] =  $newSubmission['parcela_id'];
             $cultivo['_id'] =  $newSubmission['_id'];
-            
+
             // get the cultivo_id from the creation of the cultivo
             $new_cultivo = DataMapController::newRecord($dataMap, $cultivo);
             $cultivo['cultivo_id'] =  $new_cultivo->id;
             if (array_key_exists('extra_modulo_cultivo', $cultivo['modulo_cultivo_loop'])) {
-                $cultivo_modules = $cultivo['modulos_cultivo'] . ' '. $cultivo['modulo_cultivo_loop']['extra_modulo_cultivo'];           
-                
+                $cultivo_modules = $cultivo['modulos_cultivo'] . ' '. $cultivo['modulo_cultivo_loop']['extra_modulo_cultivo'];
             } else {
                 $cultivo_modules = $cultivo['modulos_cultivo'];
             }
@@ -187,27 +183,22 @@ class GetDataFromKobo implements ShouldQueue
             $cultivo_modules = explode(' ', $cultivo_modules);
             $cultivo = $cultivo + $cultivo['modulo_cultivo_loop'];
             unset($cultivo['modulo_cultivo_loop']);
-           
+
 
             foreach ($cultivo_modules as $cultivo_module) {
+                //eventually we should get to a place where we don't need to manually map module '3' to either plagas or engermedades...
+                // but for now this will have to do...
                 if ($cultivo_module == 3) {
-                    
-                    if ( ($cultivo['problema'] == 'plagas' || $cultivo['problema'] == 'ambas') &&  $cultivo['plaga_current']!="otra") {
-                        foreach ($cultivo['plaga_repeat'] as $plaga) {
-                            $dataMap_cultivo_module = DataMap::findorfail('plagas');
-                            $plaga['_id'] =  $newSubmission['_id'];
-                            $plaga['cultivo_id'] =  $new_cultivo->id;
-                            DataMapController::newRecord($dataMap_cultivo_module, $plaga);
-                        }
+                    if ($cultivo['problema'] == 'plagas' || $cultivo['problema'] == 'ambas') {
+                        $dataMap_cultivo_module = DataMap::findorfail('plagas');
                     }
                     if ($cultivo['problema'] == 'enfermedades' || $cultivo['problema'] == 'ambas') {
                         $dataMap_cultivo_module = DataMap::findorfail('enfermedades');
-                        DataMapController::newRecord($dataMap_cultivo_module, $cultivo);
                     }
                 } else {
                     $dataMap_cultivo_module = DataMap::findorfail($cultivo_module);
-                    DataMapController::newRecord($dataMap_cultivo_module, $cultivo);
                 }
+                DataMapController::newRecord($dataMap_cultivo_module, $cultivo);
             }
         }
     }

--- a/app/Jobs/GetDataFromKobo.php
+++ b/app/Jobs/GetDataFromKobo.php
@@ -191,14 +191,16 @@ class GetDataFromKobo implements ShouldQueue
                 if ($cultivo_module == 3) {
                     if ($cultivo['problema'] == 'plagas' || $cultivo['problema'] == 'ambas') {
                         $dataMap_cultivo_module = DataMap::findorfail('plagas');
+                        DataMapController::newRecord($dataMap_cultivo_module, $cultivo);
                     }
                     if ($cultivo['problema'] == 'enfermedades' || $cultivo['problema'] == 'ambas') {
                         $dataMap_cultivo_module = DataMap::findorfail('enfermedades');
+                        DataMapController::newRecord($dataMap_cultivo_module, $cultivo);
                     }
                 } else {
                     $dataMap_cultivo_module = DataMap::findorfail($cultivo_module);
+                    DataMapController::newRecord($dataMap_cultivo_module, $cultivo);
                 }
-                DataMapController::newRecord($dataMap_cultivo_module, $cultivo);
             }
         }
     }

--- a/app/Models/LkpCultivo.php
+++ b/app/Models/LkpCultivo.php
@@ -26,11 +26,11 @@ class LkpCultivo extends Model
 
     public function cultivos()
     {
-        return $this->hasMany(Cultivos::class);
+        return $this->hasMany(Cultivo::class);
     }
 
     public function variedad()
     {
-        return $this->hasMany(VariedadList::class);
+        return $this->hasMany(LkpVariedad::class);
     }
 }

--- a/database/migrations/2020_10_09_120543_add_multiple_to_data_maps_table.php
+++ b/database/migrations/2020_10_09_120543_add_multiple_to_data_maps_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMultipleToDataMapsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('data_maps', function (Blueprint $table) {
+            $table->string('select_multiple')->nullable()->comment('if this is set, this data map is for data at a different level, based on a select_multiple and possibly a repeat group based on that select_multiple response.');
+            $table->string('repeat_group')->nullable()->comment('the name of the repeat group to look inside to find the main variables for this data map');
+            $table->string('select_multiple_other')->nullable()->comment('the name of the "enter other value" question linked to the select_multiple variable');
+            $table->string('inner_name')->nullable()->comment('the jr:choice-name() calculate field that is inside the repeat group. This is used so that we know where to place the "other" name in case there is an "other" option in the select_multiple');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('data_maps', function (Blueprint $table) {
+            $table->dropColumn('select_multiple');
+            $table->dropColumn('repeat_group');
+        });
+    }
+}

--- a/database/migrations/2020_10_09_120543_add_multiple_to_data_maps_table.php
+++ b/database/migrations/2020_10_09_120543_add_multiple_to_data_maps_table.php
@@ -15,9 +15,11 @@ class AddMultipleToDataMapsTable extends Migration
     {
         Schema::table('data_maps', function (Blueprint $table) {
             $table->string('select_multiple')->nullable()->comment('if this is set, this data map is for data at a different level, based on a select_multiple and possibly a repeat group based on that select_multiple response.');
-            $table->string('repeat_group')->nullable()->comment('the name of the repeat group to look inside to find the main variables for this data map');
             $table->string('select_multiple_other')->nullable()->comment('the name of the "enter other value" question linked to the select_multiple variable');
-            $table->string('inner_name')->nullable()->comment('the jr:choice-name() calculate field that is inside the repeat group. This is used so that we know where to place the "other" name in case there is an "other" option in the select_multiple');
+            $table->string('select_multiple_other_label')->nullable()->comment('the variable name that contains the "specify other" question. (This is so we can pull in the user-specified label)');
+            $table->string('repeat_group')->nullable()->comment('the name of the repeat group to look inside to find the main variables for this data map');
+            $table->string('inner_name')->nullable()->comment('the variable name of the calculate with the `selected-at(pos(..))` code (inside the repeat group)');
+            $table->string('innter_label')->nullable()->comment('the variable name of the calculate with the `jr:choice-name()` code (inside the repeat group)');
         });
     }
 
@@ -30,7 +32,11 @@ class AddMultipleToDataMapsTable extends Migration
     {
         Schema::table('data_maps', function (Blueprint $table) {
             $table->dropColumn('select_multiple');
+            $table->dropColumn('select_multiple_other');
+            $table->dropColumn('select_multiple_other_label');
             $table->dropColumn('repeat_group');
+            $table->dropColumn('inner_name');
+            $table->dropColumn('innter_label');
         });
     }
 }


### PR DESCRIPTION
Adding capacity for data maps to pull in multiple records from a repeat group / select multiple question combo. 

**details**:
The datamap model now accepts the following extra information: 
 - `select_multiple`: the name of the select_multiple.
 - `select_multiple_other`: the value that is taken when/if a user selects "other"
 - `select_multiple_other_label`: the variable name that contains the "specify other" question. (This is so we can pull in the user-specified label)
 - `repeat_group`: the name of the repeat group. 
- `inner_name`: the variable name of the calculate with the `selected-at(pos(..))` code (inside the repeat group)
-  `inner_label`: the variable name of the calculate with the `jr:choice-name()` code (inside the repeat group)

Example for Plagas:
![Screenshot 2020-10-13 at 15 24 22](https://user-images.githubusercontent.com/5711101/95873834-2e54c780-0d68-11eb-901e-213494909a20.png)
